### PR TITLE
STT Refactor to use the REST APIs instead of Websocket

### DIFF
--- a/.cursor/rules/core.mdc
+++ b/.cursor/rules/core.mdc
@@ -34,7 +34,6 @@ The `BaseSTT` trait defines the interface for all STT providers:
 pub struct STTResult {
     pub transcript: String,      // The transcribed text
     pub is_final: bool,          // Whether this is a final result
-    pub is_speech_final: bool,   // Whether speech segment ended
     pub confidence: f32,         // Confidence score (0.0 to 1.0)
 }
 ```

--- a/docs/azure-stt.md
+++ b/docs/azure-stt.md
@@ -227,7 +227,7 @@ Azure STT responses are converted to Sayna's unified `STTResult` format:
 |-------|-------------|
 | `transcript` | The transcribed text |
 | `is_final` | `true` when transcript won't change for this segment |
-| `is_speech_final` | `true` when speaker has finished (utterance end detected) |
+| `is_speech_final` | `true` when the speaker's turn is complete (determined by VAD + Smart Turn, not the STT provider) |
 | `confidence` | Recognition confidence score (0.0 to 1.0) |
 
 ### Speech Events
@@ -236,7 +236,7 @@ The Azure provider maps Speech Service events to Sayna's unified format:
 
 - **Interim Results** (`speech.hypothesis`): `is_final=false`, transcript may change
 - **Final Results** (`speech.phrase`): `is_final=true`, transcript is stable
-- **End of Utterance** (`speech.endDetected`): `is_speech_final=true`
+- **Speech Final**: The `is_speech_final` flag is **not set by Azure STT**. It is determined exclusively by Sayna's VAD + Smart Turn detection system (when the `stt-vad` feature is enabled). This provides consistent turn detection across all STT providers.
 
 ## Limits and Quotas
 

--- a/docs/cartesia-stt.md
+++ b/docs/cartesia-stt.md
@@ -133,8 +133,10 @@ Cartesia STT responses are converted to Sayna's unified `STTResult` format:
 |-------|-------------|
 | `transcript` | The transcribed text |
 | `is_final` | `true` when transcript won't change |
-| `is_speech_final` | `true` when speaker has finished (same as is_final for Cartesia) |
+| `is_speech_final` | `true` when the speaker's turn is complete (determined by VAD + Smart Turn, not the STT provider) |
 | `confidence` | `1.0` for final results, `0.0` for interim (Cartesia doesn't provide confidence) |
+
+**Note:** The `is_speech_final` flag is **not set by Cartesia STT**. It is determined exclusively by Sayna's VAD + Smart Turn detection system (when the `stt-vad` feature is enabled). This provides consistent turn detection across all STT providers.
 
 ### Cartesia Message Types
 

--- a/docs/google-stt.md
+++ b/docs/google-stt.md
@@ -167,7 +167,7 @@ Google STT responses are converted to Sayna's unified `STTResult` format:
 |-------|-------------|
 | `transcript` | The transcribed text |
 | `is_final` | `true` when transcript won't change for this segment |
-| `is_speech_final` | `true` when speaker has finished (utterance end detected) |
+| `is_speech_final` | `true` when the speaker's turn is complete (determined by VAD + Smart Turn, not the STT provider) |
 | `confidence` | Recognition confidence score (0.0 to 1.0) |
 
 ### Speech Events
@@ -176,7 +176,7 @@ The Google provider maps Speech-to-Text v2 events to Sayna's unified format:
 
 - **Interim Results**: `is_final=false`, transcript may change
 - **Final Results**: `is_final=true`, transcript is stable
-- **End of Utterance**: `is_speech_final=true`, maps to `END_OF_SINGLE_UTTERANCE` event
+- **Speech Final**: The `is_speech_final` flag is **not set by Google STT**. It is determined exclusively by Sayna's VAD + Smart Turn detection system (when the `stt-vad` feature is enabled). This provides consistent turn detection across all STT providers.
 
 ## Recognizers
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -978,7 +978,7 @@ components:
             description: Whether this is the final version of the transcript
           is_speech_final:
             type: boolean
-            description: Whether speech has ended
+            description: Whether the speaker's turn has ended (determined by VAD + Smart Turn detection)
           transcript:
             type: string
             description: Transcribed text

--- a/src/core/stt/azure/messages.rs
+++ b/src/core/stt/azure/messages.rs
@@ -292,7 +292,6 @@ impl SpeechPhrase {
 
         Some(STTResult::new(
             transcript, true, // is_final
-            true, // is_speech_final
             confidence,
         ))
     }
@@ -337,7 +336,6 @@ impl SpeechHypothesis {
         STTResult::new(
             self.text.clone(),
             false, // is_final
-            false, // is_speech_final
             0.0,   // confidence not available for hypotheses
         )
     }
@@ -908,7 +906,6 @@ mod tests {
         let result = result.unwrap();
         assert_eq!(result.transcript, "Hello world.");
         assert!(result.is_final);
-        assert!(result.is_speech_final);
         assert!((result.confidence - 1.0).abs() < 0.001);
     }
 
@@ -967,7 +964,6 @@ mod tests {
         let result = hypothesis.to_stt_result();
         assert_eq!(result.transcript, "partial text");
         assert!(!result.is_final);
-        assert!(!result.is_speech_final);
         assert!((result.confidence - 0.0).abs() < 0.001);
     }
 

--- a/src/core/stt/base.rs
+++ b/src/core/stt/base.rs
@@ -9,19 +9,16 @@ pub struct STTResult {
     pub transcript: String,
     /// Whether this is a final transcription result (not an interim result)
     pub is_final: bool,
-    /// Whether this marks the end of a speech segment
-    pub is_speech_final: bool,
     /// Confidence score of the transcription (0.0 to 1.0)
     pub confidence: f32,
 }
 
 impl STTResult {
     /// Creates a new STTResult
-    pub fn new(transcript: String, is_final: bool, is_speech_final: bool, confidence: f32) -> Self {
+    pub fn new(transcript: String, is_final: bool, confidence: f32) -> Self {
         Self {
             transcript,
             is_final,
-            is_speech_final,
             confidence: confidence.clamp(0.0, 1.0), // Ensure confidence is within valid range
         }
     }
@@ -275,7 +272,6 @@ mod tests {
                 let result = STTResult::new(
                     format!("Transcribed {} bytes of audio", audio_data.len()),
                     true,
-                    true,
                     0.95,
                 );
                 callback(result).await;
@@ -381,19 +377,18 @@ mod tests {
 
     #[test]
     fn test_stt_result_creation() {
-        let result = STTResult::new("Hello world".to_string(), true, true, 0.95);
+        let result = STTResult::new("Hello world".to_string(), true, 0.95);
         assert_eq!(result.transcript, "Hello world");
         assert!(result.is_final);
-        assert!(result.is_speech_final);
         assert_eq!(result.confidence, 0.95);
     }
 
     #[test]
     fn test_stt_result_confidence_clamping() {
-        let result = STTResult::new("Test".to_string(), true, false, 1.5);
+        let result = STTResult::new("Test".to_string(), true, 1.5);
         assert_eq!(result.confidence, 1.0);
 
-        let result = STTResult::new("Test".to_string(), true, false, -0.5);
+        let result = STTResult::new("Test".to_string(), true, -0.5);
         assert_eq!(result.confidence, 0.0);
     }
 
@@ -409,7 +404,7 @@ mod tests {
     #[test]
     fn test_stt_stats_update() {
         let mut stats = STTStats::default();
-        let result = STTResult::new("Test".to_string(), true, false, 0.8);
+        let result = STTResult::new("Test".to_string(), true, 0.8);
 
         stats.update_with_result(&result);
 

--- a/src/core/stt/cartesia/messages.rs
+++ b/src/core/stt/cartesia/messages.rs
@@ -97,7 +97,6 @@ impl CartesiaTranscript {
     /// |----------------|-----------------|-------|
     /// | `text` | `transcript` | Direct mapping |
     /// | `is_final` | `is_final` | Direct mapping |
-    /// | `is_final` | `is_speech_final` | Set to `true` when `is_final=true` |
     /// | - | `confidence` | `1.0` for final, `0.0` for interim |
     ///
     /// Note: Cartesia does not provide confidence scores.
@@ -105,7 +104,6 @@ impl CartesiaTranscript {
         STTResult::new(
             self.text.clone(),
             self.is_final,
-            self.is_final, // is_speech_final matches is_final
             if self.is_final { 1.0 } else { 0.0 },
         )
     }
@@ -443,7 +441,6 @@ mod tests {
 
         assert_eq!(result.transcript, "Hello world");
         assert!(result.is_final);
-        assert!(result.is_speech_final);
         assert_eq!(result.confidence, 1.0);
     }
 
@@ -459,7 +456,6 @@ mod tests {
 
         assert_eq!(result.transcript, "Hel");
         assert!(!result.is_final);
-        assert!(!result.is_speech_final);
         assert_eq!(result.confidence, 0.0);
     }
 

--- a/src/core/stt/cartesia/tests.rs
+++ b/src/core/stt/cartesia/tests.rs
@@ -583,7 +583,6 @@ mod message_helper_tests {
         let result = msg.to_stt_result().unwrap();
         assert_eq!(result.transcript, "Hello world");
         assert!(result.is_final);
-        assert!(result.is_speech_final);
         assert_eq!(result.confidence, 1.0);
     }
 
@@ -598,7 +597,6 @@ mod message_helper_tests {
         let result = msg.to_stt_result().unwrap();
         assert_eq!(result.transcript, "Hel");
         assert!(!result.is_final);
-        assert!(!result.is_speech_final);
         assert_eq!(result.confidence, 0.0);
     }
 
@@ -702,7 +700,6 @@ mod transcript_tests {
         let result = transcript.to_stt_result();
         assert_eq!(result.transcript, "Hello world");
         assert!(result.is_final);
-        assert!(result.is_speech_final);
         assert_eq!(result.confidence, 1.0);
     }
 
@@ -1137,7 +1134,6 @@ mod edge_case_tests {
         let result = transcript.to_stt_result();
         assert_eq!(result.transcript, "");
         assert!(result.is_final);
-        assert!(result.is_speech_final);
         assert_eq!(result.confidence, 1.0);
     }
 

--- a/src/core/stt/deepgram.rs
+++ b/src/core/stt/deepgram.rs
@@ -239,7 +239,6 @@ impl DeepgramSTT {
                                     let stt_result = STTResult::new(
                                         alternative.transcript.clone(),
                                         response.is_final.unwrap_or(false),
-                                        response.speech_final.unwrap_or(false),
                                         alternative.confidence,
                                     );
 
@@ -826,7 +825,6 @@ mod tests {
         assert_eq!(received_result.transcript, "Hello world");
         assert_eq!(received_result.confidence, 0.98);
         assert!(received_result.is_final);
-        assert!(received_result.is_speech_final);
     }
 
     #[tokio::test]

--- a/src/core/stt/elevenlabs/client.rs
+++ b/src/core/stt/elevenlabs/client.rs
@@ -272,7 +272,6 @@ impl ElevenLabsSTT {
                                 let stt_result = STTResult::new(
                                     partial.text,
                                     false, // is_final = false (interim)
-                                    false, // is_speech_final = false
                                     0.0,   // No confidence for partials
                                 );
 
@@ -286,7 +285,6 @@ impl ElevenLabsSTT {
                             let stt_result = STTResult::new(
                                 committed.text,
                                 true, // is_final = true
-                                true, // is_speech_final = true
                                 1.0,  // High confidence for committed
                             );
 
@@ -302,7 +300,6 @@ impl ElevenLabsSTT {
                             let stt_result = STTResult::new(
                                 committed.text,
                                 true, // is_final = true
-                                true, // is_speech_final = true
                                 confidence.clamp(0.0, 1.0),
                             );
 

--- a/src/core/stt/elevenlabs/tests.rs
+++ b/src/core/stt/elevenlabs/tests.rs
@@ -739,7 +739,6 @@ mod websocket_handler_tests {
 
         assert_eq!(stt_result.transcript, "hello world");
         assert!(!stt_result.is_final);
-        assert!(!stt_result.is_speech_final);
     }
 
     #[tokio::test]
@@ -761,7 +760,6 @@ mod websocket_handler_tests {
 
         assert_eq!(stt_result.transcript, "hello world final");
         assert!(stt_result.is_final);
-        assert!(stt_result.is_speech_final);
         assert_eq!(stt_result.confidence, 1.0);
     }
 
@@ -847,7 +845,6 @@ mod websocket_handler_tests {
 
         assert_eq!(stt_result.transcript, "hello world");
         assert!(stt_result.is_final);
-        assert!(stt_result.is_speech_final);
         assert!(stt_result.confidence > 0.0 && stt_result.confidence <= 1.0);
     }
 

--- a/src/core/stt/google/streaming.rs
+++ b/src/core/stt/google/streaming.rs
@@ -214,6 +214,7 @@ pub(super) fn chunk_audio_vec(audio_data: Vec<u8>) -> Vec<Vec<u8>> {
 
 /// Determine if this event marks the end of speech.
 /// Called on every streaming response - inlined for performance.
+#[cfg(test)]
 #[inline]
 pub(super) fn determine_speech_final(event_type: SpeechEventType, is_final: bool) -> bool {
     match event_type {
@@ -376,14 +377,12 @@ pub(super) fn handle_streaming_response(
         let stt_result = STTResult::new(
             top_alt.transcript.clone(),
             result.is_final,
-            determine_speech_final(event_type, result.is_final),
             get_confidence(top_alt.confidence, result.is_final),
         );
 
         debug!(
             transcript = %stt_result.transcript,
             is_final = stt_result.is_final,
-            is_speech_final = stt_result.is_speech_final,
             confidence = stt_result.confidence,
             "Sending transcription result"
         );

--- a/src/core/stt/google/tests/streaming.rs
+++ b/src/core/stt/google/tests/streaming.rs
@@ -230,7 +230,6 @@ fn test_handle_streaming_response_with_results() {
     let result = rx.try_recv().unwrap();
     assert_eq!(result.transcript, "Hello world");
     assert!(result.is_final);
-    assert!(result.is_speech_final);
     assert_eq!(result.confidence, 0.95);
 }
 
@@ -522,7 +521,6 @@ fn test_handle_streaming_response_interim_result() {
     let result = rx.try_recv().unwrap();
     assert_eq!(result.transcript, "Hello");
     assert!(!result.is_final);
-    assert!(!result.is_speech_final);
     assert_eq!(result.confidence, 0.0);
 }
 
@@ -553,7 +551,6 @@ fn test_handle_streaming_response_with_end_of_utterance() {
     let result = rx.try_recv().unwrap();
     assert_eq!(result.transcript, "Hello world");
     assert!(result.is_final);
-    assert!(result.is_speech_final);
     assert_eq!(result.confidence, 0.95);
 }
 
@@ -583,7 +580,6 @@ fn test_handle_streaming_response_speech_activity_end_with_final() {
 
     let result = rx.try_recv().unwrap();
     assert!(result.is_final);
-    assert!(result.is_speech_final);
 }
 
 #[test]
@@ -887,13 +883,13 @@ fn test_build_config_request_decoding_config() {
 
 #[test]
 fn test_stt_result_confidence_boundary_values() {
-    let result = STTResult::new("test".to_string(), true, true, 0.0);
+    let result = STTResult::new("test".to_string(), true, 0.0);
     assert_eq!(result.confidence, 0.0);
 
-    let result = STTResult::new("test".to_string(), true, true, 1.0);
+    let result = STTResult::new("test".to_string(), true, 1.0);
     assert_eq!(result.confidence, 1.0);
 
-    let result = STTResult::new("test".to_string(), true, true, 0.5);
+    let result = STTResult::new("test".to_string(), true, 0.5);
     assert_eq!(result.confidence, 0.5);
 }
 

--- a/src/core/voice_manager/mod.rs
+++ b/src/core/voice_manager/mod.rs
@@ -9,9 +9,9 @@
 //!
 //! - **Unified Management**: Coordinate STT and TTS providers through a single interface
 //! - **Real-time Processing**: Optimized for low-latency voice processing
-//! - **Speech Final Timing Control**: Multi-tier fallback mechanism for delayed `is_speech_final` signals:
-//!   - Primary: Wait for STT provider's `speech_final` signal (default: 2s)
-//!   - Secondary: ML-based turn detection as intelligent fallback (default: 100ms inference timeout)
+//! - **Speech Final Timing Control**: Multi-tier fallback mechanism for turn detection:
+//!   - Primary: VAD + Smart Turn detection for accurate end-of-speech detection
+//!   - Secondary: Timeout-based fallback (default: 2s) when VAD not available
 //!   - Tertiary: Hard timeout guarantee (default: 5s) - ensures no utterance waits indefinitely
 //!   - All timeouts are configurable through `SpeechFinalConfig`
 //! - **Error Handling**: Comprehensive error handling with proper error propagation

--- a/src/core/voice_manager/tests.rs
+++ b/src/core/voice_manager/tests.rs
@@ -148,8 +148,8 @@ async fn test_speech_final_timing_control() {
             *state = SpeechFinalState::new();
         }
 
-        // Send is_final=true without is_speech_final=true
-        let result1 = STTResult::new("Hello".to_string(), true, false, 0.9);
+        // Send is_final=true (turn detection will be spawned via VAD + Smart Turn path)
+        let result1 = STTResult::new("Hello".to_string(), true, 0.9);
         let processor = STTResultProcessor::default();
         let processed = processor
             .process_result(result1, speech_final_state.clone())
@@ -160,7 +160,6 @@ async fn test_speech_final_timing_control() {
         let processed_result = processed.unwrap();
         assert_eq!(processed_result.transcript, "Hello");
         assert!(processed_result.is_final);
-        assert!(!processed_result.is_speech_final);
 
         // Timer should be started and state updated
         let state = speech_final_state.read();
@@ -179,8 +178,8 @@ async fn test_speech_final_timing_control() {
             *state = SpeechFinalState::new();
         }
 
-        // Send is_final=true without is_speech_final=true
-        let result1 = STTResult::new("Test message".to_string(), true, false, 0.8);
+        // Send is_final=true (turn detection spawned via VAD + Smart Turn path)
+        let result1 = STTResult::new("Test message".to_string(), true, 0.8);
         let processor = STTResultProcessor::default();
         let processed = processor
             .process_result(result1, speech_final_state.clone())
@@ -191,7 +190,6 @@ async fn test_speech_final_timing_control() {
         let processed_result = processed.unwrap();
         assert_eq!(processed_result.transcript, "Test message");
         assert!(processed_result.is_final);
-        assert!(!processed_result.is_speech_final);
 
         // Check that timer was started and state is correct
         let state = speech_final_state.read();
@@ -200,7 +198,7 @@ async fn test_speech_final_timing_control() {
         assert!(state.turn_detection_handle.is_some());
     }
 
-    // Test Case 3: Real speech_final should cancel timer and reset state
+    // Test Case 3: Multiple is_final results should reset timer and accumulate text
     {
         let speech_final_state = Arc::new(SyncRwLock::new(SpeechFinalState::new()));
 
@@ -210,8 +208,8 @@ async fn test_speech_final_timing_control() {
             *state = SpeechFinalState::new();
         }
 
-        // Send is_final=true result to start timer
-        let result1 = STTResult::new("Hello world".to_string(), true, false, 0.9);
+        // Send first is_final=true result to start timer
+        let result1 = STTResult::new("Hello ".to_string(), true, 0.9);
         let processor = STTResultProcessor::default();
         let _processed1 = processor
             .process_result(result1, speech_final_state.clone())
@@ -222,72 +220,39 @@ async fn test_speech_final_timing_control() {
             let state = speech_final_state.read();
             assert!(state.waiting_for_speech_final.load(Ordering::Acquire));
             assert!(state.turn_detection_handle.is_some());
-            assert_eq!(state.text_buffer, "Hello world");
+            assert_eq!(state.text_buffer, "Hello ");
         }
 
-        // Send is_speech_final=true (should cancel timer and reset state)
-        let result2 = STTResult::new("final result".to_string(), true, true, 0.95);
+        // Send another is_final=true - should reset timer and accumulate text
+        let result2 = STTResult::new("world".to_string(), true, 0.95);
         let processor2 = STTResultProcessor::default();
         let processed2 = processor2
             .process_result(result2, speech_final_state.clone())
             .await;
 
-        // Should return the original speech_final result
+        // Should return the result
         assert!(processed2.is_some());
         let final_result = processed2.unwrap();
-        assert!(final_result.is_speech_final);
         assert!(final_result.is_final);
-        assert_eq!(final_result.transcript, "final result");
+        assert_eq!(final_result.transcript, "world");
         assert_eq!(final_result.confidence, 0.95);
 
-        // State should be reset
+        // State should have accumulated text and still be waiting
         let state = speech_final_state.read();
-        assert!(!state.waiting_for_speech_final.load(Ordering::Acquire));
-        assert!(state.text_buffer.is_empty());
-        assert!(state.turn_detection_handle.is_none());
-    }
-
-    // Test Case 4: Direct speech_final with no prior timer should return original result
-    {
-        let speech_final_state = Arc::new(SyncRwLock::new(SpeechFinalState::new()));
-
-        // Reset state first
-        {
-            let mut state = speech_final_state.write();
-            *state = SpeechFinalState::new();
-        }
-
-        // Send is_speech_final=true with no prior timer (direct speech final)
-        let result = STTResult::new("Direct speech final".to_string(), true, true, 0.85);
-        let processor = STTResultProcessor::default();
-        let processed = processor
-            .process_result(result, speech_final_state.clone())
-            .await;
-
-        assert!(processed.is_some());
-        let final_result = processed.unwrap();
-        assert!(final_result.is_speech_final);
-        assert!(final_result.is_final);
-        // Should return original text as-is
-        assert_eq!(final_result.transcript, "Direct speech final");
-        assert_eq!(final_result.confidence, 0.85);
-
-        // State should be reset
-        let state = speech_final_state.read();
-        assert!(!state.waiting_for_speech_final.load(Ordering::Acquire));
-        assert!(state.text_buffer.is_empty());
+        assert!(state.waiting_for_speech_final.load(Ordering::Acquire));
+        assert_eq!(state.text_buffer, "Hello world");
+        assert!(state.turn_detection_handle.is_some());
     }
 }
 
 #[tokio::test]
-async fn test_duplicate_speech_final_prevention() {
-    // Test Case 1: Timer fires, then real speech_final arrives - should prevent duplicate
+async fn test_turn_detection_timer_behavior() {
+    // Test Case 1: is_final result starts turn detection timer
     {
         let speech_final_state = Arc::new(SyncRwLock::new(SpeechFinalState::new()));
 
-        // Simulate the scenario:
-        // 1. is_final=true arrives
-        let result1 = STTResult::new("Hello world".to_string(), true, false, 0.9);
+        // is_final=true arrives
+        let result1 = STTResult::new("Hello world".to_string(), true, 0.9);
         let processor1 = STTResultProcessor::default();
         let processed1 = processor1
             .process_result(result1.clone(), speech_final_state.clone())
@@ -302,37 +267,14 @@ async fn test_duplicate_speech_final_prevention() {
             assert!(state.waiting_for_speech_final.load(Ordering::Acquire));
             assert!(state.turn_detection_handle.is_some());
         }
-
-        // 2. Simulate timer firing (mark as fired)
-        {
-            let mut state = speech_final_state.write();
-            let fire_time_ms = get_current_time_ms();
-            state
-                .turn_detection_last_fired_ms
-                .store(fire_time_ms, Ordering::Release);
-            state.last_forced_text = "Hello world".to_string();
-            state
-                .waiting_for_speech_final
-                .store(false, Ordering::Release);
-        }
-
-        // 3. Real speech_final arrives after timer fired
-        let result2 = STTResult::new("Hello world".to_string(), true, true, 0.95);
-        let processor2 = STTResultProcessor::default();
-        let processed2 = processor2
-            .process_result(result2, speech_final_state.clone())
-            .await;
-
-        // Should be None (ignored) because timer already fired
-        assert!(processed2.is_none());
     }
 
-    // Test Case 2: Multiple is_final results after timer fired should not restart timer
+    // Test Case 2: Multiple is_final results should restart timer (continuous speech)
     {
         let speech_final_state = Arc::new(SyncRwLock::new(SpeechFinalState::new()));
 
         // 1. First is_final=true
-        let result1 = STTResult::new("First".to_string(), true, false, 0.9);
+        let result1 = STTResult::new("First".to_string(), true, 0.9);
         let processor1 = STTResultProcessor::default();
         let processed1 = processor1
             .process_result(result1, speech_final_state.clone())
@@ -340,51 +282,47 @@ async fn test_duplicate_speech_final_prevention() {
 
         assert!(processed1.is_some());
 
-        // Mark timer as fired (simulate timer expiry)
-        {
-            let mut state = speech_final_state.write();
-            let old_time_ms = get_current_time_ms() - 1000; // 1 second ago
-            state
-                .turn_detection_last_fired_ms
-                .store(old_time_ms, Ordering::Release);
-            state.last_forced_text = "First".to_string();
-            state
-                .waiting_for_speech_final
-                .store(false, Ordering::Release);
-        }
-
-        // 2. Another is_final=true arrives after timer fired
-        let result2 = STTResult::new("Second".to_string(), true, false, 0.9);
-        let processor2 = STTResultProcessor::default();
-        let processed2 = processor2
-            .process_result(result2, speech_final_state.clone())
-            .await;
-
-        // Should still return the result but NOT start a new timer
-        assert!(processed2.is_some());
-        assert_eq!(processed2.unwrap().transcript, "Second");
-
-        // Verify new timer WAS started (continuous speech should work)
+        // Verify timer was started
         {
             let state = speech_final_state.read();
             assert!(state.waiting_for_speech_final.load(Ordering::Acquire));
             assert!(state.turn_detection_handle.is_some());
         }
+
+        // 2. Another is_final=true arrives (continuous speech)
+        let result2 = STTResult::new("Second".to_string(), true, 0.9);
+        let processor2 = STTResultProcessor::default();
+        let processed2 = processor2
+            .process_result(result2, speech_final_state.clone())
+            .await;
+
+        // Should still return the result and timer should be reset
+        assert!(processed2.is_some());
+        assert_eq!(processed2.unwrap().transcript, "Second");
+
+        // Verify timer is still active (reset for continuous speech)
+        {
+            let state = speech_final_state.read();
+            assert!(state.waiting_for_speech_final.load(Ordering::Acquire));
+            assert!(state.turn_detection_handle.is_some());
+            // Text should be accumulated
+            assert_eq!(state.text_buffer, "FirstSecond");
+        }
     }
 
-    // Test Case 3: New speech segment after proper reset should work normally
+    // Test Case 3: New speech segment after state reset should work normally
     {
         let speech_final_state = Arc::new(SyncRwLock::new(SpeechFinalState::new()));
 
         // First sequence: is_final=true starts timer
-        let result1 = STTResult::new("First segment".to_string(), true, false, 0.9);
+        let result1 = STTResult::new("First segment".to_string(), true, 0.9);
         let processor1 = STTResultProcessor::default();
         let processed1 = processor1
             .process_result(result1, speech_final_state.clone())
             .await;
         assert!(processed1.is_some());
 
-        // Mark timer as fired (with recent timestamp)
+        // Simulate turn detection firing and state reset
         {
             let mut state = speech_final_state.write();
             let fire_time_ms = get_current_time_ms();
@@ -392,31 +330,11 @@ async fn test_duplicate_speech_final_prevention() {
                 .turn_detection_last_fired_ms
                 .store(fire_time_ms, Ordering::Release);
             state.last_forced_text = "First segment".to_string();
-            state
-                .waiting_for_speech_final
-                .store(false, Ordering::Release);
+            state.reset_for_next_segment();
         }
 
-        // Real speech_final arrives but is ignored (timer already fired)
-        let result2 = STTResult::new("First segment".to_string(), true, true, 0.9);
-        let processor2 = STTResultProcessor::default();
-        let processed2 = processor2
-            .process_result(result2, speech_final_state.clone())
-            .await;
-        assert!(processed2.is_none()); // Ignored due to timer fired recently with same text
-
-        // Clear the state to simulate a clean new segment
-        {
-            let mut state = speech_final_state.write();
-            state.text_buffer.clear();
-            state
-                .waiting_for_speech_final
-                .store(false, Ordering::Release);
-            // Clear timer fired state to allow new timers
-        }
-
-        // Now a completely new segment starts (new is_final without speech_final)
-        let new_result = STTResult::new("New segment".to_string(), true, false, 0.9);
+        // Now a completely new segment starts
+        let new_result = STTResult::new("New segment".to_string(), true, 0.9);
         let processor_new = STTResultProcessor::default();
         let processed_new = processor_new
             .process_result(new_result, speech_final_state.clone())
@@ -425,12 +343,12 @@ async fn test_duplicate_speech_final_prevention() {
         assert!(processed_new.is_some());
         assert_eq!(processed_new.unwrap().transcript, "New segment");
 
-        // Verify new timer started for continuous speech
+        // Verify new timer started for the new segment
         {
             let state = speech_final_state.read();
-            // New timer should be started for continuous speech
             assert!(state.waiting_for_speech_final.load(Ordering::Acquire));
             assert!(state.turn_detection_handle.is_some());
+            assert_eq!(state.text_buffer, "New segment");
         }
     }
 }
@@ -445,7 +363,7 @@ mod hard_timeout_tests {
     use tokio::time::Duration;
 
     #[tokio::test]
-    async fn test_hard_timeout_fires_when_no_speech_final() {
+    async fn test_hard_timeout_fires_when_turn_detection_slow() {
         let config = STTProcessingConfig::new(
             50,  // stt_speech_final_wait_ms
             50,  // turn_detection_inference_timeout_ms
@@ -458,10 +376,11 @@ mod hard_timeout_tests {
         let callback_count = Arc::new(AtomicUsize::new(0));
         let callback_count_clone = callback_count.clone();
 
+        // Callback counts is_final results (turn detection fires these)
         let callback: STTCallback = Arc::new(move |result: STTResult| {
             let count = callback_count_clone.clone();
             Box::pin(async move {
-                if result.is_speech_final {
+                if result.is_final {
                     count.fetch_add(1, Ordering::SeqCst);
                 }
             }) as Pin<Box<dyn Future<Output = ()> + Send>>
@@ -472,7 +391,6 @@ mod hard_timeout_tests {
         let result = STTResult {
             transcript: "Hello world".to_string(),
             is_final: true,
-            is_speech_final: false,
             confidence: 0.95,
         };
 
@@ -484,7 +402,7 @@ mod hard_timeout_tests {
         assert_eq!(
             callback_count.load(Ordering::SeqCst),
             1,
-            "Hard timeout should have fired speech_final callback"
+            "Hard timeout should have fired turn detection callback"
         );
 
         let final_state = state.read();
@@ -493,64 +411,6 @@ mod hard_timeout_tests {
         assert_eq!(
             final_state.hard_timeout_deadline_ms.load(Ordering::Acquire),
             0
-        );
-    }
-
-    #[tokio::test]
-    async fn test_hard_timeout_cancelled_by_real_speech_final() {
-        let config = STTProcessingConfig::new(
-            50,  // stt_speech_final_wait_ms
-            50,  // turn_detection_inference_timeout_ms
-            500, // speech_final_hard_timeout_ms - Long timeout
-            100, // duplicate_window_ms
-        );
-
-        let processor = STTResultProcessor::new(config);
-
-        let callback_count = Arc::new(AtomicUsize::new(0));
-        let callback_count_clone = callback_count.clone();
-
-        let callback: STTCallback = Arc::new(move |result: STTResult| {
-            let count = callback_count_clone.clone();
-            Box::pin(async move {
-                if result.is_speech_final {
-                    count.fetch_add(1, Ordering::SeqCst);
-                }
-            }) as Pin<Box<dyn Future<Output = ()> + Send>>
-        });
-
-        let state = Arc::new(SyncRwLock::new(SpeechFinalState::with_callback(callback)));
-
-        let is_final_result = STTResult {
-            transcript: "Hello".to_string(),
-            is_final: true,
-            is_speech_final: false,
-            confidence: 0.95,
-        };
-
-        processor
-            .process_result(is_final_result, state.clone())
-            .await;
-
-        tokio::time::sleep(Duration::from_millis(100)).await;
-
-        let speech_final_result = STTResult {
-            transcript: "Hello world".to_string(),
-            is_final: true,
-            is_speech_final: true,
-            confidence: 0.95,
-        };
-
-        processor
-            .process_result(speech_final_result, state.clone())
-            .await;
-
-        tokio::time::sleep(Duration::from_millis(500)).await;
-
-        assert_eq!(
-            callback_count.load(Ordering::SeqCst),
-            1,
-            "Only real speech_final should fire, not hard timeout"
         );
     }
 
@@ -568,10 +428,11 @@ mod hard_timeout_tests {
         let callback_count = Arc::new(AtomicUsize::new(0));
         let callback_count_clone = callback_count.clone();
 
+        // Callback counts is_final results (turn detection fires these)
         let callback: STTCallback = Arc::new(move |result: STTResult| {
             let count = callback_count_clone.clone();
             Box::pin(async move {
-                if result.is_speech_final {
+                if result.is_final {
                     count.fetch_add(1, Ordering::SeqCst);
                 }
             }) as Pin<Box<dyn Future<Output = ()> + Send>>
@@ -582,7 +443,6 @@ mod hard_timeout_tests {
         let result1 = STTResult {
             transcript: "Hello".to_string(),
             is_final: true,
-            is_speech_final: false,
             confidence: 0.95,
         };
 
@@ -593,7 +453,6 @@ mod hard_timeout_tests {
         let result2 = STTResult {
             transcript: " world".to_string(),
             is_final: true,
-            is_speech_final: false,
             confidence: 0.95,
         };
 
@@ -609,7 +468,7 @@ mod hard_timeout_tests {
     }
 
     #[tokio::test]
-    async fn test_segment_timing_reset_after_speech_final() {
+    async fn test_segment_timing_tracks_first_is_final() {
         let config = STTProcessingConfig::default();
         let processor = STTResultProcessor::new(config);
 
@@ -619,7 +478,7 @@ mod hard_timeout_tests {
         let callback: STTCallback = Arc::new(move |result: STTResult| {
             let count = callback_count_clone.clone();
             Box::pin(async move {
-                if result.is_speech_final {
+                if result.is_final {
                     count.fetch_add(1, Ordering::SeqCst);
                 }
             }) as Pin<Box<dyn Future<Output = ()> + Send>>
@@ -630,42 +489,41 @@ mod hard_timeout_tests {
         let result = STTResult {
             transcript: "First utterance".to_string(),
             is_final: true,
-            is_speech_final: false,
             confidence: 0.95,
         };
 
         processor.process_result(result, state.clone()).await;
 
+        // Verify segment timing is set
         {
             let s = state.read();
             assert_ne!(s.segment_start_ms.load(Ordering::Acquire), 0);
             assert_ne!(s.hard_timeout_deadline_ms.load(Ordering::Acquire), 0);
         }
 
-        let speech_final = STTResult {
-            transcript: "First utterance complete".to_string(),
-            is_final: true,
-            is_speech_final: true,
-            confidence: 0.95,
-        };
+        // Simulate state reset (as if turn detection fired)
+        {
+            let mut s = state.write();
+            s.reset_for_next_segment();
+        }
 
-        processor.process_result(speech_final, state.clone()).await;
-
+        // Verify timing is reset
         {
             let s = state.read();
             assert_eq!(s.segment_start_ms.load(Ordering::Acquire), 0);
             assert_eq!(s.hard_timeout_deadline_ms.load(Ordering::Acquire), 0);
         }
 
+        // New segment starts
         let result2 = STTResult {
             transcript: "Second utterance".to_string(),
             is_final: true,
-            is_speech_final: false,
             confidence: 0.95,
         };
 
         processor.process_result(result2, state.clone()).await;
 
+        // Verify new timing is set
         {
             let s = state.read();
             assert_ne!(s.segment_start_ms.load(Ordering::Acquire), 0);

--- a/src/core/voice_manager/turn_detection_tasks.rs
+++ b/src/core/voice_manager/turn_detection_tasks.rs
@@ -183,7 +183,6 @@ pub async fn fire_speech_final(
         let forced_result = STTResult {
             transcript: String::new(),
             is_final: true,
-            is_speech_final: true,
             confidence: 1.0,
         };
 

--- a/src/handlers/ws/config_handler.rs
+++ b/src/handlers/ws/config_handler.rs
@@ -390,10 +390,14 @@ async fn register_stt_callback(
         .on_stt_result(move |result: STTResult| {
             let message_tx = message_tx_clone.clone();
             Box::pin(async move {
+                // VAD + Smart Turn path produces results with empty transcript and is_final=true
+                // These indicate the speaker has finished their turn
+                let is_speech_final =
+                    result.is_final && result.transcript.is_empty() && result.confidence >= 1.0;
                 let msg = OutgoingMessage::STTResult {
                     transcript: result.transcript,
                     is_final: result.is_final,
-                    is_speech_final: result.is_speech_final,
+                    is_speech_final,
                     confidence: result.confidence,
                 };
                 let _ = message_tx.send(MessageRoute::Outgoing(msg)).await;

--- a/src/handlers/ws/messages.rs
+++ b/src/handlers/ws/messages.rs
@@ -179,7 +179,7 @@ pub enum OutgoingMessage {
         transcript: String,
         /// Whether this is the final version of the transcript
         is_final: bool,
-        /// Whether speech has ended
+        /// Whether the speaker has finished speaking (turn detection via VAD + Smart Turn)
         is_speech_final: bool,
         /// Confidence score (0.0 to 1.0)
         confidence: f32,

--- a/src/handlers/ws/tests.rs
+++ b/src/handlers/ws/tests.rs
@@ -299,7 +299,7 @@ fn test_outgoing_message_serialization() {
     let stt_msg = OutgoingMessage::STTResult {
         transcript: "Hello world".to_string(),
         is_final: true,
-        is_speech_final: true,
+        is_speech_final: false,
         confidence: 0.95,
     };
 
@@ -307,6 +307,7 @@ fn test_outgoing_message_serialization() {
     assert!(json.contains("\"type\":\"stt_result\""));
     assert!(json.contains("Hello world"));
     assert!(json.contains("0.95"));
+    assert!(json.contains("\"is_speech_final\":false"));
 
     // Test error message
     let error_msg = OutgoingMessage::Error {

--- a/tests/turn_detect_test.rs
+++ b/tests/turn_detect_test.rs
@@ -2132,7 +2132,7 @@ mod stt_result_processor_integration_tests {
             let received = callback_received_clone.clone();
             Box::pin(async move {
                 count.fetch_add(1, Ordering::SeqCst);
-                if result.is_speech_final {
+                if result.is_final && result.transcript.is_empty() {
                     received.store(true, Ordering::SeqCst);
                 }
             }) as Pin<Box<dyn Future<Output = ()> + Send>>
@@ -2231,7 +2231,7 @@ mod stt_result_processor_integration_tests {
         let callback: STTCallback = Arc::new(move |result: STTResult| {
             let count = callback_count_clone.clone();
             Box::pin(async move {
-                if result.is_speech_final {
+                if result.is_final && result.transcript.is_empty() {
                     count.fetch_add(1, Ordering::SeqCst);
                 }
             }) as Pin<Box<dyn Future<Output = ()> + Send>>
@@ -2362,7 +2362,7 @@ mod stt_result_processor_integration_tests {
         let callback: STTCallback = Arc::new(move |result: STTResult| {
             let count = callback_count_clone.clone();
             Box::pin(async move {
-                if result.is_speech_final {
+                if result.is_final && result.transcript.is_empty() {
                     count.fetch_add(1, Ordering::SeqCst);
                 }
             }) as Pin<Box<dyn Future<Output = ()> + Send>>
@@ -2453,7 +2453,7 @@ mod stt_result_processor_integration_tests {
         let callback: STTCallback = Arc::new(move |result: STTResult| {
             let count = callback_count_clone.clone();
             Box::pin(async move {
-                if result.is_speech_final {
+                if result.is_final && result.transcript.is_empty() {
                     count.fetch_add(1, Ordering::SeqCst);
                 }
             }) as Pin<Box<dyn Future<Output = ()> + Send>>
@@ -2586,7 +2586,7 @@ mod stt_result_processor_integration_tests {
         let callback: STTCallback = Arc::new(move |result: STTResult| {
             let count = callback_count_clone.clone();
             Box::pin(async move {
-                if result.is_speech_final {
+                if result.is_final && result.transcript.is_empty() {
                     count.fetch_add(1, Ordering::SeqCst);
                 }
             }) as Pin<Box<dyn Future<Output = ()> + Send>>
@@ -2651,7 +2651,7 @@ mod stt_result_processor_integration_tests {
         let callback: STTCallback = Arc::new(move |result: STTResult| {
             let count = callback_count_clone.clone();
             Box::pin(async move {
-                if result.is_speech_final {
+                if result.is_final && result.transcript.is_empty() {
                     count.fetch_add(1, Ordering::SeqCst);
                 }
             }) as Pin<Box<dyn Future<Output = ()> + Send>>
@@ -2703,7 +2703,7 @@ mod stt_result_processor_integration_tests {
         let callback: STTCallback = Arc::new(move |result: STTResult| {
             let count = callback_count_clone.clone();
             Box::pin(async move {
-                if result.is_speech_final {
+                if result.is_final && result.transcript.is_empty() {
                     count.fetch_add(1, Ordering::SeqCst);
                 }
             }) as Pin<Box<dyn Future<Output = ()> + Send>>
@@ -2761,7 +2761,7 @@ mod stt_result_processor_integration_tests {
         let callback: STTCallback = Arc::new(move |result: STTResult| {
             let count = callback_count_clone.clone();
             Box::pin(async move {
-                if result.is_speech_final {
+                if result.is_final && result.transcript.is_empty() {
                     count.fetch_add(1, Ordering::SeqCst);
                 }
             }) as Pin<Box<dyn Future<Output = ()> + Send>>
@@ -2820,7 +2820,7 @@ mod stt_result_processor_integration_tests {
         let callback: STTCallback = Arc::new(move |result: STTResult| {
             let count = callback_count_clone.clone();
             Box::pin(async move {
-                if result.is_speech_final {
+                if result.is_final && result.transcript.is_empty() {
                     count.fetch_add(1, Ordering::SeqCst);
                 }
             }) as Pin<Box<dyn Future<Output = ()> + Send>>
@@ -2975,7 +2975,7 @@ mod stt_result_processor_integration_tests {
         let callback: STTCallback = Arc::new(move |result: STTResult| {
             let count = callback_count_clone.clone();
             Box::pin(async move {
-                if result.is_speech_final {
+                if result.is_final && result.transcript.is_empty() {
                     count.fetch_add(1, Ordering::SeqCst);
                 }
             }) as Pin<Box<dyn Future<Output = ()> + Send>>

--- a/tests/vad_e2e_test.rs
+++ b/tests/vad_e2e_test.rs
@@ -142,21 +142,19 @@ fn test_vad_silence_triggers_turn_detection() {
     );
 }
 
-/// Test that VAD-based speech_final includes correct properties
+/// Test that VAD-based turn detection result includes correct properties
 #[test]
-fn test_vad_speech_final_result_format() {
-    // Create a speech_final result as the VAD system would emit
+fn test_vad_turn_detection_result_format() {
+    // Create a turn detection result as the VAD + Smart Turn system would emit
     let result = STTResult {
-        transcript: String::new(), // VAD speech_final has empty transcript
+        transcript: String::new(), // Turn detection result has empty transcript
         is_final: true,
-        is_speech_final: true,
         confidence: 1.0,
     };
 
     // Verify result structure matches expected format
     assert!(result.transcript.is_empty());
     assert!(result.is_final);
-    assert!(result.is_speech_final);
     assert_eq!(result.confidence, 1.0);
 }
 


### PR DESCRIPTION
Websocket usage for the STT providers like Deepgram and ElevenLabs makes it super difficult to scale and control the cost. REST APIs cost less, but we have to specifically handle the VAD + Turn detection correctly to process specific audio chunks.